### PR TITLE
breaking: Rewrite to use an underlying `Schema`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,20 @@
 
 #### 💥 Breaking
 
-- Update Node.js requirement to v10.
+- Updated Node.js requirement to v10.
 - Values are now type cast once all checks and validations have ran. This may cause unexpected
   results in production, but is not exactly breaking.
+- Updated `custom()` callbacks to receive a `Schema` as the 2nd argument instead of a struct object.
 - Removed and inlined all `check*` methods as we don't want them publicly chainable.
-- Renamed `Builder#runChecks()` method to `run()`.
+- Renamed `Builder#runChecks()` method to `run()` and reworked the arguments.
 - **[ts]** Added visibility modifiers to many internal properties and methods.
 
 #### 🚀 Updates
 
+- Add new `Schema` class for handling the building and validation of structs.
+- Add new `tuple()` predicate and builder.
 - Add support for default values via factory functions.
 - Add `Builder#validate()` to run stand-alone validation with a builder.
-- Add new `tuple()` predicate and builder.
 - **[array,object,string]** Add `sizeOf()` method.
 - **[number]** Add `float()`, `int()`, `negative()`, and `positive()` methods.
 - **[string]** Add `lowerCase()` and `upperCase()` methods.

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -110,7 +110,7 @@ optimal(
 );
 ```
 
-## Stand-alone Validation
+## Predicate Validation
 
 All of the examples in this documentation handle validation through the `optimal()` function, which
 requires an object and blueprint ahead of time. But what if you just want to validate a number,

--- a/docs/predicates.md
+++ b/docs/predicates.md
@@ -99,7 +99,7 @@ optimal(
 
 ## Custom
 
-The `custom(cb: (value: any, struct: object) => void, default: any)` predicate verifies a value
+The `custom(cb: (value: any, schema: Schema) => void, default: any)` predicate verifies a value
 based on a callback. The 1st argument is the callback, which accepts the value to be validated, and
 the struct object. The 2nd argument is the default value, which must be explicitly defined.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,6 +1,6 @@
 # Usage
 
-All Optimal functionality is handled through a single function, `optimal()`, which requires a
+Most functionality is handled through a single function, `optimal()`, which requires a
 [struct](#struct), [blueprint](#blueprint), and optional configuration [options](#options). To
 understand its power, lets define a class that accepts an options object in the constructor.
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     ],
     "eslint": {
       "rules": {
-        "default-param-last": "off"
+        "default-param-last": "off",
+        "no-param-reassign": "off"
       }
     }
   },

--- a/src/ArrayBuilder.ts
+++ b/src/ArrayBuilder.ts
@@ -15,12 +15,7 @@ export default class ArrayBuilder<T> extends CollectionBuilder<ArrayOf<T>> {
         const nextValue = [...value];
 
         value.forEach((item: T, i: number) => {
-          nextValue[i] = contents.run(
-            item,
-            `${path}[${i}]`,
-            this.currentStruct,
-            this.options,
-          )!;
+          nextValue[i] = contents.run(item, `${path}[${i}]`, this.schema!)!;
         });
 
         return nextValue;

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -3,10 +3,10 @@ import {
   SupportedType,
   CheckerCallback,
   CustomCallback,
-  OptimalOptions,
   FuncOf,
   DefaultValue,
   DefaultValueFactory,
+  SchemaOptions,
 } from './types';
 
 export interface TemporalStruct {
@@ -36,7 +36,7 @@ export default class Builder<T> {
 
   protected noErrorPrefix: boolean = false;
 
-  protected options: OptimalOptions = {};
+  protected options: SchemaOptions = {};
 
   constructor(type: SupportedType, defaultValue: DefaultValue<T>, bypassFactory: boolean = false) {
     if (__DEV__) {
@@ -277,7 +277,7 @@ export default class Builder<T> {
     initialValue: T | undefined,
     path: string,
     struct: object,
-    options: OptimalOptions = {},
+    options: SchemaOptions = {},
   ): T | null {
     this.currentStruct = struct;
     this.options = options;

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -1,3 +1,4 @@
+import Schema from './Schema';
 import isObject from './isObject';
 import {
   SupportedType,
@@ -6,7 +7,6 @@ import {
   FuncOf,
   DefaultValue,
   DefaultValueFactory,
-  SchemaOptions,
 } from './types';
 
 export interface TemporalStruct {
@@ -16,11 +16,11 @@ export interface TemporalStruct {
 export default class Builder<T> {
   defaultValue?: T;
 
+  schema?: Schema<{}>;
+
   type: SupportedType;
 
   protected checks: CheckerCallback[] = [];
-
-  protected currentStruct: object = {};
 
   protected defaultValueFactory?: DefaultValueFactory<T>;
 
@@ -35,8 +35,6 @@ export default class Builder<T> {
   protected isRequired: boolean = false;
 
   protected noErrorPrefix: boolean = false;
-
-  protected options: SchemaOptions = {};
 
   constructor(type: SupportedType, defaultValue: DefaultValue<T>, bypassFactory: boolean = false) {
     if (__DEV__) {
@@ -66,7 +64,7 @@ export default class Builder<T> {
 
       this.addCheck(path => {
         const checkedKeys = [this.key(path), ...keys];
-        const struct = this.currentStruct as TemporalStruct;
+        const struct = (this.schema?.struct ?? {}) as TemporalStruct;
         const undefs = checkedKeys.filter(
           key => typeof struct[key] === 'undefined' || struct[key] === null,
         );
@@ -96,7 +94,7 @@ export default class Builder<T> {
   /**
    * Set a callback to run custom logic.
    */
-  custom<S = object>(callback: CustomCallback<T, S>): this {
+  custom<S extends object = object>(callback: CustomCallback<T, S>): this {
     if (__DEV__) {
       this.invariant(
         typeof callback === 'function',
@@ -105,7 +103,7 @@ export default class Builder<T> {
 
       this.addCheck((path, value) => {
         try {
-          callback(value, (this.currentStruct as unknown) as S);
+          callback(value, this.schema as Schema<S>);
         } catch (error) {
           this.invariant(false, error.message, path);
         }
@@ -140,22 +138,22 @@ export default class Builder<T> {
         return;
       }
 
-      const { file, name } = this.options;
+      const { filePath, schemaName } = this.schema || {};
       const error = this.errorMessage || message;
       let prefix = '';
 
       if (path) {
-        if (name) {
-          prefix += `Invalid ${name} field "${path}"`;
+        if (schemaName) {
+          prefix += `Invalid ${schemaName} field "${path}"`;
         } else {
           prefix += `Invalid field "${path}"`;
         }
-      } else if (name) {
-        prefix += name;
+      } else if (schemaName) {
+        prefix += schemaName;
       }
 
-      if (file) {
-        prefix += ` in ${file}`;
+      if (filePath) {
+        prefix += ` in ${filePath}`;
       }
 
       if (prefix && !this.noErrorPrefix) {
@@ -215,7 +213,7 @@ export default class Builder<T> {
    */
   only(): this {
     if (__DEV__) {
-      const defaultValue = this.getDefaultValue(this.currentStruct);
+      const defaultValue = this.getDefaultValue();
 
       this.invariant(
         // eslint-disable-next-line valid-typeof
@@ -244,7 +242,7 @@ export default class Builder<T> {
 
       this.addCheck(path => {
         const orKeys = [this.key(path), ...keys];
-        const struct = this.currentStruct as TemporalStruct;
+        const struct = (this.schema?.struct ?? {}) as TemporalStruct;
         const defs = orKeys.filter(
           key => typeof struct[key] !== 'undefined' && struct[key] !== null,
         );
@@ -273,15 +271,9 @@ export default class Builder<T> {
    * If a value is undefined, inherit the default value, else throw if required.
    * If nullable and the value is null, return early.
    */
-  run(
-    initialValue: T | undefined,
-    path: string,
-    struct: object,
-    options: SchemaOptions = {},
-  ): T | null {
-    this.currentStruct = struct;
-    this.options = options;
-    this.defaultValue = this.getDefaultValue(struct);
+  run(initialValue: T | undefined, path: string, schema: Schema<{}>): T | null {
+    this.schema = schema;
+    this.defaultValue = this.getDefaultValue();
 
     let value = initialValue;
 
@@ -354,7 +346,7 @@ export default class Builder<T> {
 
       this.addCheck(path => {
         const xorKeys = [this.key(path), ...keys];
-        const struct = this.currentStruct as TemporalStruct;
+        const struct = (this.schema?.struct ?? {}) as TemporalStruct;
         const defs = xorKeys.filter(
           key => typeof struct[key] !== 'undefined' && struct[key] !== null,
         );
@@ -410,9 +402,9 @@ export default class Builder<T> {
   /**
    * Return the possible default value.
    */
-  protected getDefaultValue(struct: object) {
+  protected getDefaultValue() {
     if (this.defaultValueFactory) {
-      return this.defaultValueFactory(struct);
+      return this.defaultValueFactory(this.schema?.struct ?? {});
     }
 
     return this.defaultValue;
@@ -422,7 +414,7 @@ export default class Builder<T> {
    * Return true if the value matches the default value and the builder is optional.
    */
   protected isOptionalDefault(value: unknown): boolean {
-    return !this.isRequired && value === this.getDefaultValue(this.currentStruct);
+    return !this.isRequired && value === this.getDefaultValue();
   }
 
   /**
@@ -435,7 +427,7 @@ export default class Builder<T> {
   }
 }
 
-export function custom<T, S = object>(
+export function custom<T, S extends object = object>(
   callback: CustomCallback<T, S>,
   defaultValue: DefaultValue<T>,
 ) /* infer */ {

--- a/src/ObjectBuilder.ts
+++ b/src/ObjectBuilder.ts
@@ -17,12 +17,7 @@ export default class ObjectBuilder<T> extends CollectionBuilder<ObjectOf<T>> {
         const nextValue = { ...value };
 
         Object.keys(value).forEach(key => {
-          nextValue[key] = contents.run(
-            value[key],
-            `${path}.${key}`,
-            this.currentStruct,
-            this.options,
-          )!;
+          nextValue[key] = contents.run(value[key], `${path}.${key}`, this.schema!)!;
         });
 
         return nextValue;

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -1,0 +1,73 @@
+import Builder from './Builder';
+import isObject from './isObject';
+import typeOf from './typeOf';
+import { SchemaOptions, Blueprint } from './types';
+
+export default class Schema<T extends object> {
+  blueprint: Blueprint<T>;
+
+  options: SchemaOptions;
+
+  constructor(blueprint: Blueprint<T>, options: SchemaOptions = {}) {
+    if (__DEV__) {
+      if (!isObject(blueprint)) {
+        throw new TypeError('A schema blueprint is required.');
+      } else if (!isObject(options)) {
+        throw new TypeError('Schema options must be a plain object.');
+      }
+    }
+
+    this.blueprint = blueprint;
+    this.options = options;
+  }
+
+  build(struct: Partial<T>): Required<T> {
+    if (__DEV__) {
+      if (!isObject(struct)) {
+        throw new TypeError(`Schema requires a plain object, found ${typeOf(struct)}.`);
+      }
+    }
+
+    const { prefix } = this.options;
+    const unknownFields: Partial<T> = { ...struct };
+    const builtStruct: Partial<T> = {};
+
+    // Validate using the blueprint
+    Object.keys(this.blueprint).forEach(baseKey => {
+      const key = baseKey as keyof T;
+      const value = struct[key];
+      const builder = this.blueprint[key];
+      const path = String(prefix ? `${prefix}.${key}` : key);
+
+      // Run validation checks and support both v1 and v2
+      if (
+        builder instanceof Builder ||
+        (isObject(builder) && (builder as Function).constructor.name.endsWith('Builder'))
+      ) {
+        builtStruct[key] = builder.run(value, path, struct, this.options)!;
+
+        // Oops
+      } else if (__DEV__) {
+        throw new Error(`Unknown blueprint for "${path}". Must be a builder.`);
+      }
+
+      // Delete the prop and mark it as known
+      delete unknownFields[key];
+    });
+
+    // Handle unknown options
+    if (this.options.unknown) {
+      Object.assign(builtStruct, unknownFields);
+    } else if (__DEV__) {
+      const unknownKeys = Object.keys(unknownFields);
+
+      if (unknownKeys.length > 0) {
+        const message = prefix ? `Unknown "${prefix}" fields` : 'Unknown fields';
+
+        throw new Error(`${message}: ${unknownKeys.join(', ')}.`);
+      }
+    }
+
+    return builtStruct as Required<T>;
+  }
+}

--- a/src/ShapeBuilder.ts
+++ b/src/ShapeBuilder.ts
@@ -1,7 +1,7 @@
 import Builder from './Builder';
 import isObject from './isObject';
 import optimal from './optimal';
-import { Blueprint, OptimalOptions } from './types';
+import { Blueprint, SchemaOptions } from './types';
 
 export default class ShapeBuilder<T extends object> extends Builder<T> {
   protected contents: Blueprint<T>;
@@ -31,7 +31,7 @@ export default class ShapeBuilder<T extends object> extends Builder<T> {
     return this;
   }
 
-  run(value: T | undefined, path: string, struct: object, options: OptimalOptions = {}) {
+  run(value: T | undefined, path: string, struct: object, options: SchemaOptions = {}) {
     const object = value || this.getDefaultValue(struct) || {};
 
     if (__DEV__) {

--- a/src/ShapeBuilder.ts
+++ b/src/ShapeBuilder.ts
@@ -1,7 +1,8 @@
-import Builder from './Builder';
-import isObject from './isObject';
 import optimal from './optimal';
-import { Blueprint, SchemaOptions } from './types';
+import Builder from './Builder';
+import Schema from './Schema';
+import isObject from './isObject';
+import { Blueprint } from './types';
 
 export default class ShapeBuilder<T extends object> extends Builder<T> {
   protected contents: Blueprint<T>;
@@ -31,15 +32,16 @@ export default class ShapeBuilder<T extends object> extends Builder<T> {
     return this;
   }
 
-  run(value: T | undefined, path: string, struct: object, options: SchemaOptions = {}) {
-    const object = value || this.getDefaultValue(struct) || {};
+  run(value: T | undefined, path: string, schema: Schema<{}>) {
+    const object = value || this.getDefaultValue() || {};
 
     if (__DEV__) {
       this.invariant(isObject(object), 'Value passed to shape must be an object.', path);
     }
 
     return optimal(object, this.contents, {
-      ...options,
+      file: schema.filePath,
+      name: schema.schemaName,
       prefix: path,
       unknown: !this.isExact,
     });

--- a/src/TupleBuilder.ts
+++ b/src/TupleBuilder.ts
@@ -43,7 +43,7 @@ export default class TupleBuilder<T extends unknown[] = unknown[]> extends Build
     const nextValue = value ? [...value] : [];
 
     this.contents.forEach((content, i) => {
-      nextValue[i] = content.run(nextValue[i], `${path}[${i}]`, this.currentStruct, this.options)!;
+      nextValue[i] = content.run(nextValue[i], `${path}[${i}]`, this.schema!)!;
     });
 
     return nextValue as T;

--- a/src/UnionBuilder.ts
+++ b/src/UnionBuilder.ts
@@ -49,8 +49,8 @@ export default class UnionBuilder<T = unknown> extends Builder<T> {
             builder.type === 'custom'
           ) {
             // @ts-ignore
-            builder.noErrorPrefix = true; // eslint-disable-line no-param-reassign
-            nextValue = builder.run(value, path, this.currentStruct, this.options);
+            builder.noErrorPrefix = true;
+            nextValue = builder.run(value, path, this.schema!);
 
             return true;
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 import optimal from './optimal';
+import Schema from './Schema';
 import Builder, { custom, func } from './Builder';
 import ArrayBuilder, { array } from './ArrayBuilder';
 import BooleanBuilder, { bool } from './BooleanBuilder';
@@ -52,6 +53,7 @@ export {
 };
 
 export {
+  Schema,
   Builder,
   ArrayBuilder,
   BooleanBuilder,

--- a/src/optimal.ts
+++ b/src/optimal.ts
@@ -1,70 +1,9 @@
-import Builder from './Builder';
-import isObject from './isObject';
-import typeOf from './typeOf';
-import { Blueprint, OptimalOptions } from './types';
-
-function buildAndCheck<Struct extends object>(
-  blueprint: Blueprint<Struct>,
-  struct: Partial<Struct>,
-  options: OptimalOptions = {},
-  parentPath: string = '',
-): Required<Struct> {
-  const unknownFields: Partial<Struct> = { ...struct };
-  const builtStruct: Partial<Struct> = {};
-
-  // Validate using the blueprint
-  Object.keys(blueprint).forEach(baseKey => {
-    const key = baseKey as keyof Struct;
-    const value = struct[key];
-    const builder = blueprint[key];
-    const path = String(parentPath ? `${parentPath}.${key}` : key);
-
-    // Run validation checks and support both v1 and v2
-    if (
-      builder instanceof Builder ||
-      (isObject(builder) && (builder as Function).constructor.name.endsWith('Builder'))
-    ) {
-      builtStruct[key] = builder.run(value, path, struct, options)!;
-
-      // Oops
-    } else if (__DEV__) {
-      throw new Error(`Unknown blueprint for "${path}". Must be a builder.`);
-    }
-
-    // Delete the prop and mark it as known
-    delete unknownFields[key];
-  });
-
-  // Handle unknown options
-  if (options.unknown) {
-    // eslint-disable-next-line compat/compat
-    Object.assign(builtStruct, unknownFields);
-  } else if (__DEV__) {
-    const unknownKeys = Object.keys(unknownFields);
-
-    if (unknownKeys.length > 0) {
-      const message = parentPath ? `Unknown "${parentPath}" fields` : 'Unknown fields';
-
-      throw new Error(`${message}: ${unknownKeys.join(', ')}.`);
-    }
-  }
-
-  return builtStruct as Required<Struct>;
-}
+import { Blueprint, SchemaOptions } from './types';
+import Schema from './Schema';
 
 export default function optimal<
   Struct extends object,
   Construct extends object = { [K in keyof Struct]?: unknown }
->(struct: Construct, blueprint: Blueprint<Struct>, options: OptimalOptions = {}): Required<Struct> {
-  if (__DEV__) {
-    if (!isObject(struct)) {
-      throw new TypeError(`Optimal requires a plain object, found ${typeOf(struct)}.`);
-    } else if (!isObject(options)) {
-      throw new TypeError('Optimal options must be a plain object.');
-    } else if (!isObject(blueprint)) {
-      throw new TypeError('A blueprint is required.');
-    }
-  }
-
-  return buildAndCheck(blueprint, struct, options, options.prefix);
+>(struct: Construct, blueprint: Blueprint<Struct>, options: SchemaOptions = {}): Required<Struct> {
+  return new Schema(blueprint, options).build(struct);
 }

--- a/src/optimal.ts
+++ b/src/optimal.ts
@@ -1,9 +1,30 @@
-import { Blueprint, SchemaOptions } from './types';
 import Schema from './Schema';
+import isObject from './isObject';
+import { Blueprint, OptimalOptions } from './types';
 
 export default function optimal<
   Struct extends object,
   Construct extends object = { [K in keyof Struct]?: unknown }
->(struct: Construct, blueprint: Blueprint<Struct>, options: SchemaOptions = {}): Required<Struct> {
-  return new Schema(blueprint, options).build(struct);
+>(struct: Construct, blueprint: Blueprint<Struct>, options: OptimalOptions = {}): Required<Struct> {
+  if (__DEV__) {
+    if (!isObject(options)) {
+      throw new TypeError('Optimal options must be a plain object.');
+    }
+  }
+
+  const schema = new Schema(blueprint);
+
+  if (options.name) {
+    schema.setName(options.name);
+  }
+
+  if (options.file) {
+    schema.setFile(options.file);
+  }
+
+  if (options.unknown) {
+    schema.allowUnknown();
+  }
+
+  return schema.build(struct, options.prefix);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import Builder from './Builder';
+import Schema from './Schema';
 
 export type ArrayOf<T> = T[];
 
@@ -15,13 +16,13 @@ export type Blueprint<Struct extends object> = { [K in keyof Struct]-?: Builder<
 
 export type CheckerCallback<T = any> = (path: string, value: T) => unknown;
 
-export type CustomCallback<T, S = object> = (value: T, struct: S) => void;
+export type CustomCallback<T, S extends object = object> = (value: T, schema: Schema<S>) => void;
 
 export type DefaultValueFactory<T> = (struct: any) => T;
 
 export type DefaultValue<T> = T | DefaultValueFactory<T>;
 
-export interface SchemaOptions {
+export interface OptimalOptions {
   file?: string;
   name?: string;
   prefix?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export type DefaultValueFactory<T> = (struct: any) => T;
 
 export type DefaultValue<T> = T | DefaultValueFactory<T>;
 
-export interface OptimalOptions {
+export interface SchemaOptions {
   file?: string;
   name?: string;
   prefix?: string;

--- a/tests/Builder.test.ts
+++ b/tests/Builder.test.ts
@@ -1,11 +1,15 @@
+import { Schema } from '../src';
 import Builder, { custom, func } from '../src/Builder';
 import { runChecks } from './helpers';
 
 describe('Builder', () => {
+  let schema: Schema<{}>;
   let builder: Builder<unknown>;
 
   beforeEach(() => {
+    schema = new Schema({});
     builder = new Builder('string', 'foo');
+    builder.schema = schema;
   });
 
   it('errors if default value is undefined', () => {
@@ -184,13 +188,17 @@ describe('Builder', () => {
 
   describe('custom()', () => {
     it('errors if no callback', () => {
-      // @ts-ignore
-      expect(() => builder.custom()).toThrow('Custom blueprints require a validation function.');
+      expect(() =>
+        // @ts-ignore
+        builder.custom(),
+      ).toThrow('Custom blueprints require a validation function.');
     });
 
     it('errors if callback is not a function', () => {
-      // @ts-ignore
-      expect(() => builder.custom(123)).toThrow('Custom blueprints require a validation function.');
+      expect(() =>
+        // @ts-ignore
+        builder.custom(123),
+      ).toThrow('Custom blueprints require a validation function.');
     });
 
     it('triggers callback function', () => {
@@ -210,8 +218,8 @@ describe('Builder', () => {
     });
 
     it('is passed entire options object', () => {
-      builder = custom<unknown, { foo?: number; bar?: number }>((value, options) => {
-        if (options.foo && options.bar) {
+      builder = custom<unknown, { foo?: number; bar?: number }>((value, s) => {
+        if (s.struct.foo && s.struct.bar) {
           throw new Error('This will error!');
         }
       }, 0);
@@ -245,8 +253,7 @@ describe('Builder', () => {
 
     it('includes a class name', () => {
       expect(() => {
-        // @ts-ignore Allow access
-        builder.options.name = 'FooBar';
+        schema.setName('FooBar');
 
         builder.invariant(false, 'Failure', 'foo.bar');
       }).toThrowErrorMatchingSnapshot();
@@ -254,8 +261,7 @@ describe('Builder', () => {
 
     it('includes a class name when no path', () => {
       expect(() => {
-        // @ts-ignore Allow access
-        builder.options.name = 'FooBar';
+        schema.setName('FooBar');
 
         builder.invariant(false, 'Failure');
       }).toThrowErrorMatchingSnapshot();
@@ -263,8 +269,7 @@ describe('Builder', () => {
 
     it('includes a file name', () => {
       expect(() => {
-        // @ts-ignore Allow access
-        builder.options.file = 'package.json';
+        schema.setFile('package.json');
 
         builder.invariant(false, 'Failure', 'foo.bar');
       }).toThrowErrorMatchingSnapshot();
@@ -272,10 +277,7 @@ describe('Builder', () => {
 
     it('includes a file and class name', () => {
       expect(() => {
-        // @ts-ignore Allow access
-        builder.options.file = 'package.json';
-        // @ts-ignore Allow access
-        builder.options.name = 'FooBar';
+        schema.setName('FooBar').setFile('package.json');
 
         builder.invariant(false, 'Failure', 'foo.bar');
       }).toThrowErrorMatchingSnapshot();

--- a/tests/ShapeBuilder.test.ts
+++ b/tests/ShapeBuilder.test.ts
@@ -74,12 +74,10 @@ describe('ShapeBuilder', () => {
 
     it('doesnt error for unknown fields if unknown is true', () => {
       expect(() => {
-        builder.run(
+        runChecks(
+          builder,
           // @ts-ignore Allow invalid fields
           { qux: 123, oof: 'abc' },
-          'key',
-          {},
-          { unknown: true },
         );
       }).not.toThrow();
     });

--- a/tests/__snapshots__/optimal.test.ts.snap
+++ b/tests/__snapshots__/optimal.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Optimal errors if a non-builder is passed within the blueprint 1`] = `"Unknown blueprint for \\"foo\\". Must be a builder."`;
 
-exports[`Optimal errors if a non-object config is passed 1`] = `"Schema options must be a plain object."`;
+exports[`Optimal errors if a non-object config is passed 1`] = `"Optimal options must be a plain object."`;
 
 exports[`Optimal errors if a non-object is passed 1`] = `"Schema requires a plain object, found array."`;
 

--- a/tests/__snapshots__/optimal.test.ts.snap
+++ b/tests/__snapshots__/optimal.test.ts.snap
@@ -2,17 +2,17 @@
 
 exports[`Optimal errors if a non-builder is passed within the blueprint 1`] = `"Unknown blueprint for \\"foo\\". Must be a builder."`;
 
-exports[`Optimal errors if a non-object config is passed 1`] = `"Optimal options must be a plain object."`;
+exports[`Optimal errors if a non-object config is passed 1`] = `"Schema options must be a plain object."`;
 
-exports[`Optimal errors if a non-object is passed 1`] = `"Optimal requires a plain object, found array."`;
+exports[`Optimal errors if a non-object is passed 1`] = `"Schema requires a plain object, found array."`;
 
-exports[`Optimal errors if a non-object is passed 2`] = `"Optimal requires a plain object, found number."`;
+exports[`Optimal errors if a non-object is passed 2`] = `"Schema requires a plain object, found number."`;
 
-exports[`Optimal errors if a non-object is passed 3`] = `"Optimal requires a plain object, found string."`;
+exports[`Optimal errors if a non-object is passed 3`] = `"Schema requires a plain object, found string."`;
 
-exports[`Optimal errors if a non-object is passed 4`] = `"Optimal requires a plain object, found function."`;
+exports[`Optimal errors if a non-object is passed 4`] = `"Schema requires a plain object, found function."`;
 
-exports[`Optimal errors if a non-object is passed as a blueprint 1`] = `"A blueprint is required."`;
+exports[`Optimal errors if a non-object is passed as a blueprint 1`] = `"A schema blueprint is required."`;
 
 exports[`Optimal logical operators handles AND 1`] = `"All of these fields must be defined: foo, bar, baz"`;
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,11 +1,17 @@
 import Builder from '../src/Builder';
+import Schema from '../src/Schema';
 
 export function runChecks<T>(
   builder: Builder<T>,
   value?: Partial<T> | null,
   { key = 'key', struct }: { key?: string; struct?: object } = {},
 ): T | null {
-  return builder.run(value as T, key, struct ?? { [key]: value });
+  const schema = new Schema({});
+  schema.struct = struct ?? { [key]: value };
+
+  builder.schema = schema;
+
+  return builder.run(value as T, key, schema);
 }
 
 export function runInProd(cb: () => unknown) {


### PR DESCRIPTION
Encapsulating all this logic into a `Schema` class makes it far easier to use.